### PR TITLE
feat(ansible): disable Ubuntu screen saver locking


### DIFF
--- a/ansible/zero.yml
+++ b/ansible/zero.yml
@@ -349,3 +349,13 @@
       timezone:
         name: "{{ ansible_facts.timezone }}"
       when: ansible_facts.timezone is defined
+
+    #------------------------------------------------------------------------------------------------------------------------
+    # REMOVE SCREEN SAVER LOCK
+    #------------------------------------------------------------------------------------------------------------------------
+    - name: Remove screen saver locking
+      community.general.dconf:
+        key: "/org/gnome/desktop/screensaver/ununtu-lock-on-suspend"
+        value: "false"
+        state: present
+ 


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
- Added an Ansible task to disable screen saver locking on Ubuntu by setting the Gnome desktop screensaver setting `ununtu-lock-on-suspend` to `false`.



