### PR TITLE
fix: correct typo in dconf key for screen saver lock

### DIFF
--- a/ansible/zero.yml
+++ b/ansible/zero.yml
@@ -355,6 +355,7 @@
     #------------------------------------------------------------------------------------------------------------------------
     - name: Remove screen saver locking
       community.general.dconf:
+        # For Gnome version X.Y
         key: "/org/gnome/desktop/screensaver/ubuntu-lock-on-suspend"
         value: "false"
         state: present

--- a/ansible/zero.yml
+++ b/ansible/zero.yml
@@ -355,7 +355,7 @@
     #------------------------------------------------------------------------------------------------------------------------
     - name: Remove screen saver locking
       community.general.dconf:
-        key: "/org/gnome/desktop/screensaver/ununtu-lock-on-suspend"
+        key: "/org/gnome/desktop/screensaver/ubuntu-lock-on-suspend"
         value: "false"
         state: present
  


### PR DESCRIPTION
## **User description**
fix typo


___

## **Type**
Bug fix


___

## **Description**
- Fixed a typo in the `community.general.dconf` key from `/org/gnome/desktop/screensaver/ununtu-lock-on-suspend` to `/org/gnome/desktop/screensaver/ubuntu-lock-on-suspend` in `ansible/zero.yml`.


