### PR TITLE
feat: update screen saver lock disabling method in ansible playbook


### DIFF
--- a/ansible/zero.yml
+++ b/ansible/zero.yml
@@ -355,5 +355,8 @@
     #------------------------------------------------------------------------------------------------------------------------
   
     - name: Disable lock screen on suspend with gsettings
-      command: gsettings set org.gnome.desktop.screensaver ubuntu-lock-on-suspend false
+      - name: Disable lock screen on suspend with gsettings
+        command: gsettings set org.gnome.desktop.screensaver ubuntu-lock-on-suspend false
+        register: gsettings_output
+        changed_when: "'No such schema' not in gsettings_output.stderr"
  

--- a/ansible/zero.yml
+++ b/ansible/zero.yml
@@ -353,10 +353,7 @@
     #------------------------------------------------------------------------------------------------------------------------
     # REMOVE SCREEN SAVER LOCK
     #------------------------------------------------------------------------------------------------------------------------
-    - name: Remove screen saver locking
-      community.general.dconf:
-        # For Gnome version X.Y
-        key: "/org/gnome/desktop/screensaver/ubuntu-lock-on-suspend"
-        value: "false"
-        state: present
+  
+    - name: Disable lock screen on suspend with gsettings
+      command: gsettings set org.gnome.desktop.screensaver ubuntu-lock-on-suspend false
  


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Replaced the approach for disabling screen saver locking on suspend in the Ansible playbook `zero.yml`. The previous method using `community.general.dconf` module has been replaced with a direct `gsettings` command for better compatibility and reliability.


