### PR TITLE
fix(ansible): remove duplicate task declaration in zero.yml


### DIFF
--- a/ansible/zero.yml
+++ b/ansible/zero.yml
@@ -355,8 +355,7 @@
     #------------------------------------------------------------------------------------------------------------------------
   
     - name: Disable lock screen on suspend with gsettings
-      - name: Disable lock screen on suspend with gsettings
-        command: gsettings set org.gnome.desktop.screensaver ubuntu-lock-on-suspend false
-        register: gsettings_output
-        changed_when: "'No such schema' not in gsettings_output.stderr"
- 
+      command: gsettings set org.gnome.desktop.screensaver ubuntu-lock-on-suspend false
+      register: gsettings_output
+      changed_when: "'No such schema' not in gsettings_output.stderr"
+


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Fixed a duplication issue in `ansible/zero.yml` where the task "Disable lock screen on suspend with gsettings" was mistakenly declared twice. The duplicate declaration has been removed, leaving a single, correctly formatted task.



