### PR TITLE
fix(ansible): correct indentation for disabling screensaver command


### DIFF
--- a/ansible/zero.yml
+++ b/ansible/zero.yml
@@ -357,4 +357,4 @@
     - name: Disable lock screen on suspend with gsettings
       command: gsettings set org.gnome.desktop.screensaver ubuntu-lock-on-suspend false
     - name: Disable screensaver
-    command: gsettings set org.gnome.desktop.screensaver lock-enabled false
+      command: gsettings set org.gnome.desktop.screensaver lock-enabled false

--- a/ansible/zero.yml
+++ b/ansible/zero.yml
@@ -357,4 +357,7 @@
     - name: Disable lock screen on suspend with gsettings
       command: gsettings set org.gnome.desktop.screensaver ubuntu-lock-on-suspend false
     - name: Disable screensaver
-      command: gsettings set org.gnome.desktop.screensaver lock-enabled false
+      ansible.builtin.gnome_settings:
+        schema: "org.gnome.desktop.screensaver"
+        key: "lock-enabled"
+        value: "false"


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Fixed indentation issue in `ansible/zero.yml` for the command to disable the screensaver.



