### PR TITLE
fix ansible script in zero.yml

### DIFF
--- a/ansible/zero.yml
+++ b/ansible/zero.yml
@@ -356,6 +356,7 @@
   
     - name: Disable lock screen on suspend with gsettings
       command: gsettings set org.gnome.desktop.screensaver ubuntu-lock-on-suspend false
+    
     - name: Disable screensaver
       ansible.builtin.gnome_settings:
         schema: "org.gnome.desktop.screensaver"


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
- Added a new Ansible task to disable the screensaver by setting the `lock-enabled` key to false using the `ansible.builtin.gnome_settings` module in `zero.yml`.


