### PR TITLE
Disable lockscreen

### DIFF
--- a/ansible/zero.yml
+++ b/ansible/zero.yml
@@ -349,5 +349,10 @@
       timezone:
         name: "{{ ansible_facts.timezone }}"
       when: ansible_facts.timezone is defined
-
-  
+    # ------------------------------------------------------------------------------------------------------------------
+    # TURN OFF LOCK SCREEN
+    # ------------------------------------------------------------------------------------------------------------------
+    - name: Disable lock screen
+      community.general.dconf:
+        key: '/org/gnome/desktop/lockdown/disable-lock-screen'
+        value: 'true'        


### PR DESCRIPTION
## **User description**
add lock screen disable to gsettings


___

## **Type**
enhancement


___

## **Description**
- Added a new task to the Ansible playbook (`zero.yml`) to disable the GNOME lock screen using the `community.general.dconf` module.
- The key `/org/gnome/desktop/lockdown/disable-lock-screen` is set to `true` to ensure the lock screen is disabled.


