### PR TITLE
Update zero.yml

### DIFF
--- a/ansible/zero.yml
+++ b/ansible/zero.yml
@@ -322,7 +322,7 @@
           - xdg-utils
         state: latest
     
-    -name: Install openssl 3
+    - name: Install openssl 3
       ansible.builtin.apt:
         name:
           - openssl-tool

--- a/ansible/zero.yml
+++ b/ansible/zero.yml
@@ -321,7 +321,13 @@
           - libqt5x11extras5
           - xdg-utils
         state: latest
-
+    
+    -name: Install openssl 3
+      ansible.builtin.apt:
+        name:
+          - openssl-tool
+        state: latest
+        
     - name: Check if the Parsec package exists and get its details
       ansible.builtin.stat:
         path: '/home/zero/.config/linkin/parsec-linux.deb'


### PR DESCRIPTION
### **User description**
added open ssl 3, required for parsec


___

### **PR Type**
Enhancement


___

### **Description**
- Added a new task to install OpenSSL 3 using `ansible.builtin.apt` in the `zero.yml` playbook.
- Ensured the OpenSSL 3 package is installed to support Parsec.



