### PR TITLE
Update zero.yml

### DIFF
--- a/ansible/zero.yml
+++ b/ansible/zero.yml
@@ -321,7 +321,13 @@
           - libqt5x11extras5
           - xdg-utils
         state: latest
-
+        
+    - name: Install Openssl 3 required for parsec
+      ansible.builtin.apt:
+        name:
+          - openssl
+        state: latest
+        
     - name: Check if the Parsec package exists and get its details
       ansible.builtin.stat:
         path: '/home/zero/.config/linkin/parsec-linux.deb'


### PR DESCRIPTION
### **User description**
add Openssl 3 for parsec


___

### **PR Type**
Enhancement


___

### **Description**
- Added a task to install Openssl 3, which is required for Parsec, in the `ansible/zero.yml` playbook.



