### PR TITLE
Update menu

### DIFF
--- a/fluxbox/menu
+++ b/fluxbox/menu
@@ -1,5 +1,5 @@
 [begin] (TECHNOLINK)
-[exec] (Amazon Workspaces) {/opt/workspacesclient/workspacesclient} </opt/workspacesclient/Assets/AppIcon-512.png>
+[exec] (Amazon Workspaces) {workspacesclient} </opt/workspacesclient/Assets/AppIcon-512.png>
 [exec] (Parsec) {parsecd} </usr/share/icons/hicolor/256x256/apps/parsecd.png>
 [separator]
 [exec] (Restart) {sudo reboot}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Updated the command for launching Amazon Workspaces in the Fluxbox menu to use `workspacesclient` instead of the full path `/opt/workspacesclient/workspacesclient`.



