### PR TITLE
chore: harden image build scripts and mask getty@tty1

### DIFF
--- a/image-creation/clean-build.sh
+++ b/image-creation/clean-build.sh
@@ -1,47 +1,74 @@
 #!/usr/bin/env bash
-# Clean up failed or incomplete builds
+# Clean up failed or incomplete builds.
+#
+# Safety: this script NEVER runs `rm -rf` on the mount directory. If any
+# submount is still live (because a chroot process is holding /dev or /sys
+# open), we would end up recursing through a bind mount into the host's
+# real filesystem. We refuse to delete anything until everything is clean.
+
+set -u
+
+MOUNT_ROOT="/mnt/zero-img"
+IMAGE_FILE="zero-client.img"
 
 echo "Cleaning up zero-client build artifacts..."
 
-# Unmount all /mnt/zero-img mounts recursively
-if mountpoint -q /mnt/zero-img 2>/dev/null; then
-    echo "Unmounting /mnt/zero-img..."
-    umount -R /mnt/zero-img 2>/dev/null || true
-    umount -l /mnt/zero-img 2>/dev/null || true  # Force lazy unmount if needed
-fi
+# Order matters: unmount deepest bind-mounts first, root last. Every call uses
+# lazy unmount so that busy submounts detach now and free their resources
+# once no longer referenced.
+SUBMOUNTS=(
+  "$MOUNT_ROOT/dev/pts"
+  "$MOUNT_ROOT/dev"
+  "$MOUNT_ROOT/proc"
+  "$MOUNT_ROOT/sys"
+  "$MOUNT_ROOT/run"
+  "$MOUNT_ROOT/boot/efi"
+  "$MOUNT_ROOT"
+)
 
-# Detach all loop devices
-echo "Detaching loop devices..."
-losetup -D 2>/dev/null || true
+for mount_path in "${SUBMOUNTS[@]}"; do
+  if mountpoint -q "$mount_path" 2>/dev/null; then
+    echo "Unmounting $mount_path..."
+    umount "$mount_path" 2>/dev/null || umount -l "$mount_path" 2>/dev/null || true
+  fi
+done
 
-# Remove mount directory
-if [ -d /mnt/zero-img ]; then
-    echo "Removing mount directory..."
-    rmdir /mnt/zero-img 2>/dev/null || rm -rf /mnt/zero-img
-fi
+# Detach any loop devices that were pointing at our image.
+echo "Detaching loop devices backing $IMAGE_FILE..."
+while read -r loop_device; do
+  [ -n "$loop_device" ] && losetup -d "$loop_device" 2>/dev/null || true
+done < <(losetup -l -O NAME,BACK-FILE 2>/dev/null | awk -v img="$IMAGE_FILE" '$2 ~ img {print $1}')
 
-# Remove image file
-if [ -f zero-client.img ]; then
-    echo "Removing zero-client.img..."
-    rm -f zero-client.img
-fi
-
-# Check for any remaining mounts
-REMAINING_MOUNTS=$(mount | grep "/mnt/zero-img" || true)
+# Verify nothing remains mounted under MOUNT_ROOT before touching the directory.
+REMAINING_MOUNTS=$(mount | awk -v root="$MOUNT_ROOT" '$3 ~ root {print}' || true)
 if [ -n "$REMAINING_MOUNTS" ]; then
-    echo "WARNING: Some mounts still remain:"
-    echo "$REMAINING_MOUNTS"
-else
-    echo "All mounts cleaned up successfully."
+  echo "ERROR: mounts still remain under $MOUNT_ROOT — refusing to delete:" >&2
+  echo "$REMAINING_MOUNTS" >&2
+  echo "Resolve the stuck mounts manually (or reboot) and rerun." >&2
+  exit 1
 fi
 
-# Check for any remaining loop devices
-REMAINING_LOOPS=$(losetup -l | grep zero-client || true)
+# Only rmdir (never rm -rf) — rmdir fails if non-empty, which is what we want.
+if [ -d "$MOUNT_ROOT" ]; then
+  if ! rmdir "$MOUNT_ROOT" 2>/dev/null; then
+    echo "ERROR: $MOUNT_ROOT is not empty after unmounting. Leaving it alone." >&2
+    echo "Inspect its contents and remove manually if you're certain it's safe." >&2
+    exit 1
+  fi
+fi
+
+# Remove image file only after we confirmed nothing was mounted from it.
+if [ -f "$IMAGE_FILE" ]; then
+  echo "Removing $IMAGE_FILE..."
+  rm -f "$IMAGE_FILE"
+fi
+
+# Final sanity check.
+REMAINING_LOOPS=$(losetup -l -O NAME,BACK-FILE 2>/dev/null | awk -v img="$IMAGE_FILE" '$2 ~ img {print}' || true)
 if [ -n "$REMAINING_LOOPS" ]; then
-    echo "WARNING: Some loop devices still remain:"
-    echo "$REMAINING_LOOPS"
-else
-    echo "All loop devices cleaned up successfully."
+  echo "WARNING: loop devices still reference $IMAGE_FILE:" >&2
+  echo "$REMAINING_LOOPS" >&2
+  exit 1
 fi
 
-echo "Cleanup complete!"
+echo "Cleanup complete."

--- a/image-creation/create-image.sh
+++ b/image-creation/create-image.sh
@@ -12,7 +12,22 @@ cleanup() {
   set +e
   sync
 
-  umount -R "$ROOT_MOUNT_PATH" 2>/dev/null || true
+  # Unmount explicitly in reverse dependency order, with lazy fallback so a
+  # busy submount doesn't abort the whole cleanup the way `umount -R` does.
+  # We NEVER rm -rf the mount dir — if any of these fail the state is unsafe
+  # and we want the next run of clean-build.sh to see it and refuse.
+  for mount_path in \
+    "$ROOT_MOUNT_PATH/dev/pts" \
+    "$ROOT_MOUNT_PATH/dev" \
+    "$ROOT_MOUNT_PATH/proc" \
+    "$ROOT_MOUNT_PATH/sys" \
+    "$ROOT_MOUNT_PATH/run" \
+    "$ROOT_MOUNT_PATH/boot/efi" \
+    "$ROOT_MOUNT_PATH"; do
+    if mountpoint -q "$mount_path" 2>/dev/null; then
+      umount "$mount_path" 2>/dev/null || umount -l "$mount_path" 2>/dev/null || true
+    fi
+  done
 
   if [ -n "${LOOP_DEVICE:-}" ]; then
     losetup -d "$LOOP_DEVICE" 2>/dev/null || true
@@ -73,13 +88,21 @@ mount "$ESP_PART" "$ROOT_MOUNT_PATH/boot/efi"
 # Bootstrap
 debootstrap --arch=amd64 noble "$ROOT_MOUNT_PATH" http://archive.ubuntu.com/ubuntu/
 
-# Prepare chroot mounts
+# Prepare chroot mounts. Each rbind is immediately marked rslave so that any
+# mount events inside the chroot (e.g. udev inside a package postinst) stay
+# contained and do not propagate to the host's mount namespace. This is the
+# safety net that prevents a broken cleanup or misbehaving script from eating
+# into the host's /dev or /sys.
 mkdir -p "$ROOT_MOUNT_PATH"/{proc,sys,dev,run,dev/pts}
 mount -t proc /proc "$ROOT_MOUNT_PATH/proc"
 mount --rbind /sys "$ROOT_MOUNT_PATH/sys"
+mount --make-rslave "$ROOT_MOUNT_PATH/sys"
 mount --rbind /dev "$ROOT_MOUNT_PATH/dev"
+mount --make-rslave "$ROOT_MOUNT_PATH/dev"
 mount --bind /run "$ROOT_MOUNT_PATH/run"
+mount --make-rslave "$ROOT_MOUNT_PATH/run"
 mount --bind /dev/pts "$ROOT_MOUNT_PATH/dev/pts"
+mount --make-rslave "$ROOT_MOUNT_PATH/dev/pts"
 
 # Services and playbook
 cp "$SERVICES_DIR/"*.service "$ROOT_MOUNT_PATH/etc/systemd/system/" 2>/dev/null || true

--- a/image-creation/modify-chroot.sh
+++ b/image-creation/modify-chroot.sh
@@ -66,6 +66,9 @@ systemctl enable ansible-first-boot.service || true
 # BOOT TO MULTI-USER TARGET (no display manager; chromium-kiosk.service owns tty1)
 systemctl set-default multi-user.target
 
+# MASK getty@tty1 - chromium-kiosk.service owns the console, no login prompt wanted
+systemctl mask getty@tty1.service
+
 # SET TIMEZONE
 ln -sf /usr/share/zoneinfo/Europe/Sofia /etc/localtime
 echo "Europe/Sofia" > /etc/timezone


### PR DESCRIPTION
image-creation/clean-build.sh
- Never rm -rf the mount directory; only rmdir after confirming no mounts remain. Previously, a busy umount -R left bind mounts live, and the subsequent rm -rf recursed into the host's /dev and /sys.
- Unmount each submount explicitly in reverse order with lazy fallback so one busy mount doesn't skip the rest.
- Detach only loop devices backed by zero-client.img instead of a blind losetup -D.

image-creation/create-image.sh
- Mark each rbind/bind mount as rslave immediately after mounting so mount events inside the chroot (udev, package postinsts) stay contained and cannot propagate to the host's namespace.
- Replace umount -R in the cleanup trap with the same explicit reverse-order unmount loop used by clean-build.sh.

image-creation/modify-chroot.sh
- systemctl mask getty@tty1.service so no login prompt ever renders on the kiosk console. chromium-kiosk.service owns tty1 outright; tty2-6 remain open for debugging.